### PR TITLE
Fixed Bug : Lexer is now capable of finding single digit integers from source code

### DIFF
--- a/documentation/lexical_analyser.md
+++ b/documentation/lexical_analyser.md
@@ -240,4 +240,4 @@ However, I have to check the last item for an end statement too because if the l
 
 # **Bugs to fix**
 
-- Entering a number like '1', '9' or '3' cause a mess up in the lexer but naything longer than one decimal such as '10' or '287' is fine.
+

--- a/src/lexer.py
+++ b/src/lexer.py
@@ -132,7 +132,7 @@ class Lexer(object):
             elif word in "{}": tokens.append(["SCOPE_DEFINER", word])
 
             # Identify all integer (number) values
-            elif re.match(".[0-9]", word): 
+            elif re.match("[0-9]", word): 
                 
                 # This will check if there is an end statement at the end of an integer and remove it if there is
                 if word[len(word) - 1] == ';': tokens.append(["INTEGER", word[:-1]])


### PR DESCRIPTION
Did this by changing the regex comparison of integer from .[0-9] to [0-9] , I am not certain if there are any side effects of this .